### PR TITLE
Add C++ linting and package header

### DIFF
--- a/.github/workflows/Cpp-lint-check.yaml
+++ b/.github/workflows/Cpp-lint-check.yaml
@@ -1,0 +1,31 @@
+# GitHub Action to run cpplint recursively on all pushes and pull requests
+# https://github.com/cpplint/GitHub-Action-for-cpplint
+
+on:
+  push:
+    paths:
+     - "src/**"
+     - "inst/include/**"
+  pull_request:
+    branches:
+      - "*"
+
+name: Cpp-lint-check
+
+jobs:
+  cpplint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v2
+      - run: pip install cpplint
+      - run: cpplint --filter="-build/c++14, -build/include_subdir" --exclude="src/RcppExports.cpp" src/*.cpp
+      - run: cpplint --filter="-build/c++14, -build/include_subdir" --exclude="inst/include/iraca.h" inst/include/*.h
+
+  cppcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: sudo apt-get install cppcheck
+      - run: cppcheck --std=c++14 -i src/RcppExports.cpp --enable=performance,portability,warning,style --error-exitcode=1 src
+      - run: cppcheck --std=c++14 --language=c++ --enable=performance,portability,warning,style --error-exitcode=1 inst/include/*.h

--- a/inst/include/iraca.h
+++ b/inst/include/iraca.h
@@ -1,0 +1,16 @@
+// Copyright 2023 'iraca' authors. See repository licence in LICENSE.md.
+// Written manually to allow header export
+// copied from https://github.com/r-pkg-examples/rcpp-shared-cpp-functions
+
+#ifndef iraca_iraca_H_
+#define iraca_iraca_H_
+
+// [[Rcpp::plugins(cpp14)]]
+// [[Rcpp::depends(BH)]]
+
+// Include the Rcpp header
+#include <Rcpp.h>
+
+// add headers here, paths relative to this file
+
+#endif  // iraca_iraca_H_

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -1,15 +1,15 @@
+// Copyright 2023 'iraca' authors. See repository licence in LICENSE.md.
 #include <Rcpp.h>
-using namespace Rcpp;
 
 //' @title Test fun
 //' @param n Integer for the last element in the sequence
 //' @export
 // [[Rcpp::export]]
 Rcpp::NumericVector get_numbers(const int n) {
-  Rcpp::NumericVector vec (n);
-  for(int i = 1; i <= n; i++) {
+  Rcpp::NumericVector vec(n);
+  for (int i = 1; i <= n; i++) {
     vec[i - 1] = i;
   }
-  
+
   return vec;
 }


### PR DESCRIPTION
This PR:

1. Fixes #5 by adding the C++ linting workflows copied from {epidemics},
2. Fixes #9 by adding a package header, `inst/include/iraca.h`.